### PR TITLE
fix: mapbox token

### DIFF
--- a/app.json
+++ b/app.json
@@ -46,7 +46,7 @@
       "@rnmapbox/maps",
       {
         "RNMapboxMapsImpl": "maplibre",
-        "RNMapboxMapsDownloadToken": "pk.eyJ1IjoibWFyYW5kdSIsImEiOiJjbHVsbmkzdzcxMTc2Mm5vM2ptbmY1MGowIn0.nu8kJv9TuY0gsxUxjeDj-w"
+        "RNMapboxMapsDownloadToken": "pk.eyJ1IjoibWFyYW5kdSIsImEiOiJjbTZwZzIwajMwMW12MmlvbTIwamNvZ2N5In0.csWymnXyrz5qepiCBZMlyQ"
       }
     ]
   ]

--- a/app/config/map-settings.ts
+++ b/app/config/map-settings.ts
@@ -1,4 +1,4 @@
-export const mapbox_token = 'pk.eyJ1IjoibWFyYW5kdSIsImEiOiJjbHVsbmkzdzcxMTc2Mm5vM2ptbmY1MGowIn0.nu8kJv9TuY0gsxUxjeDj-w';
+export const mapbox_token = 'pk.eyJ1IjoibWFyYW5kdSIsImEiOiJjbTZwZzIwajMwMW12MmlvbTIwamNvZ2N5In0.csWymnXyrz5qepiCBZMlyQ';
 export const mapbox_base_path = 'https://api.mapbox.com';
 export const map_size = {
     width: 800,


### PR DESCRIPTION
Se modifica el token utilizado por Mapbox ya que el original fue modificado en la consola de Mapbox por cuestiones de seguridad.